### PR TITLE
Support `go tool` command and deprecate `-use_go_run` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var Iset = []any{
 ```
 
 ```
-$ bulkmockgen -use_go_run Iset -- -package mock_foo -destination ./mock_foo/mock.go
+$ bulkmockgen -exec_mode go_run Iset -- -package mock_foo -destination ./mock_foo/mock.go
 ```
 
 You can use bulkmockgen with `go:generate` comment.
@@ -39,7 +39,7 @@ You can use bulkmockgen with `go:generate` comment.
 ```go
 package foo
 
-//go:generate bulkmockgen -use_go_run Iset -- -package mock_foo -destination ./mock_foo/mock.go
+//go:generate bulkmockgen -exec_mode go_run Iset -- -package mock_foo -destination ./mock_foo/mock.go
 
 var Iset = []any{
 	new(IFoo),

--- a/cmd/bulkmockgen/main.go
+++ b/cmd/bulkmockgen/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	useGoRun = flag.Bool("use_go_run", false, "Whether to use go run command to execute mockgen; defaults to false")
+	useGoRun = flag.Bool("use_go_run", false, "(Deprecated) Whether to use go run command to execute mockgen; defaults to false")
 
 	flagExecMode = flag.String("exec_mode", "direct", "How to execute mockgen. Supported values are: direct, go_run, go_tool")
 

--- a/cmd/bulkmockgen/main.go
+++ b/cmd/bulkmockgen/main.go
@@ -16,6 +16,8 @@ import (
 var (
 	useGoRun = flag.Bool("use_go_run", false, "Whether to use go run command to execute mockgen; defaults to false")
 
+	flagExecMode = flag.String("exec_mode", "direct", "How to execute mockgen. Supported values are: direct, go_run, go_tool")
+
 	dryRun = flag.Bool("dry_run", false, "Print command to be executed and exit")
 )
 
@@ -36,6 +38,17 @@ func main() {
 	execMode := generator.ExecModeDirect
 	if *useGoRun {
 		execMode = generator.ExecModeGoRun
+	} else {
+		switch *flagExecMode {
+		case "direct":
+			execMode = generator.ExecModeDirect
+		case "go_run":
+			execMode = generator.ExecModeGoRun
+		case "go_tool":
+			execMode = generator.ExecModeGoTool
+		default:
+			log.Fatalf("unsupported exec mode (%s)", *flagExecMode)
+		}
 	}
 	g := &generator.Generator{
 		ExecMode:    execMode,

--- a/cmd/bulkmockgen/main.go
+++ b/cmd/bulkmockgen/main.go
@@ -15,7 +15,8 @@ import (
 
 var (
 	useGoRun = flag.Bool("use_go_run", false, "Whether to use go run command to execute mockgen; defaults to false")
-	dryRun   = flag.Bool("dry_run", false, "Print command to be executed and exit")
+
+	dryRun = flag.Bool("dry_run", false, "Print command to be executed and exit")
 )
 
 func main() {
@@ -32,8 +33,12 @@ func main() {
 		log.Fatal("rest separator (--) is required")
 	}
 
+	execMode := generator.ExecModeDirect
+	if *useGoRun {
+		execMode = generator.ExecModeGoRun
+	}
 	g := &generator.Generator{
-		UseGoRun:    *useGoRun,
+		ExecMode:    execMode,
 		DryRun:      *dryRun,
 		MockSetName: mockSetName,
 		RestArgs:    args[restSeparatorIdx+1:],

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -24,6 +24,8 @@ const (
 	ExecModeDirect ExecMode = iota + 1
 
 	ExecModeGoRun
+
+	ExecModeGoTool
 )
 
 func (e ExecMode) Command() (string, []string) {
@@ -32,6 +34,8 @@ func (e ExecMode) Command() (string, []string) {
 		return "mockgen", []string{}
 	case ExecModeGoRun:
 		return "go", []string{"run", mockgenPackage}
+	case ExecModeGoTool:
+		return "go", []string{"tool", mockgenPackage}
 	default:
 		panic("unsupported exec mode")
 	}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -18,10 +18,29 @@ const (
 	mockgenPackage = "go.uber.org/mock/mockgen"
 )
 
+type ExecMode int
+
+const (
+	ExecModeDirect ExecMode = iota + 1
+
+	ExecModeGoRun
+)
+
+func (e ExecMode) Command() (string, []string) {
+	switch e {
+	case ExecModeDirect:
+		return "mockgen", []string{}
+	case ExecModeGoRun:
+		return "go", []string{"run", mockgenPackage}
+	default:
+		panic("unsupported exec mode")
+	}
+}
+
 type runnerFactory func(ctx context.Context, cmdExecutable string, cmdArgs ...string) Runner
 
 type Generator struct {
-	UseGoRun    bool
+	ExecMode    ExecMode
 	DryRun      bool
 	MockSetName string
 	RestArgs    []string
@@ -33,14 +52,7 @@ func (g *Generator) Generate(ctx context.Context, rf runnerFactory) error {
 		return err
 	}
 
-	var cmdExecutable string
-	var cmdArgs []string
-	if g.UseGoRun {
-		cmdExecutable = "go"
-		cmdArgs = append(cmdArgs, "run", mockgenPackage)
-	} else {
-		cmdExecutable = "mockgen"
-	}
+	cmdExecutable, cmdArgs := g.ExecMode.Command()
 	cmdArgs = append(cmdArgs, g.RestArgs...)
 	if externalPkg != "" {
 		cmdArgs = append(cmdArgs, externalPkg)
@@ -100,7 +112,7 @@ func (g *Generator) findMockSetFromDirectory(sourceDir string) ([]string, string
 					}
 
 					splittedImpPath := strings.Split(impPath, "/")
-					if externalPkg == splittedImpPath[len(splittedImpPath) - 1] {
+					if externalPkg == splittedImpPath[len(splittedImpPath)-1] {
 						externalPkg = impPath
 						break
 					}

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -35,7 +35,7 @@ func TestGenerate(t *testing.T) {
 			name:    "basic",
 			baseDir: "fixtures/multifile",
 			g: &Generator{
-				UseGoRun:    false,
+				ExecMode:    ExecModeDirect,
 				DryRun:      false,
 				MockSetName: "MockInterfaces",
 				RestArgs:    []string{"-package", "mock_multifile", "-destination", "mock_multifile/mock.go"},
@@ -47,7 +47,7 @@ func TestGenerate(t *testing.T) {
 			name:    "with go run",
 			baseDir: "fixtures/multifile",
 			g: &Generator{
-				UseGoRun:    true,
+				ExecMode:    ExecModeGoRun,
 				DryRun:      false,
 				MockSetName: "MockInterfaces",
 				RestArgs:    []string{"-package", "mock_multifile", "-destination", "mock_multifile/mock.go"},
@@ -59,7 +59,7 @@ func TestGenerate(t *testing.T) {
 			name:    "with external package",
 			baseDir: "fixtures/external",
 			g: &Generator{
-				UseGoRun:    false,
+				ExecMode:    ExecModeDirect,
 				DryRun:      false,
 				MockSetName: "MockInterfaces",
 				RestArgs:    []string{"-package", "mock_sql", "-destination", "mock_sql/mock.go"},

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -56,6 +56,18 @@ func TestGenerate(t *testing.T) {
 			wantCmdArgs:       []string{"run", "go.uber.org/mock/mockgen", "-package", "mock_multifile", "-destination", "mock_multifile/mock.go", ".", "IFoo,IBar"},
 		},
 		{
+			name:    "with go tool",
+			baseDir: "fixtures/multifile",
+			g: &Generator{
+				ExecMode:    ExecModeGoTool,
+				DryRun:      false,
+				MockSetName: "MockInterfaces",
+				RestArgs:    []string{"-package", "mock_multifile", "-destination", "mock_multifile/mock.go"},
+			},
+			wantCmdExecutable: "go",
+			wantCmdArgs:       []string{"tool", "go.uber.org/mock/mockgen", "-package", "mock_multifile", "-destination", "mock_multifile/mock.go", ".", "IFoo,IBar"},
+		},
+		{
 			name:    "with external package",
 			baseDir: "fixtures/external",
 			g: &Generator{


### PR DESCRIPTION
This PR introduces `-exec_mode` command line option for bulkmockgen. `-exec_mode` can take either of the following values:

- `direct`: execute `mockgen` directly.
- `go_run`: execute `mockgen` via `go run` command.
- `go_tool`: execute `mockgen` via `go tool` command. ([New in Go 1.24](https://tip.golang.org/doc/go1.24#go-command))

And this PR makes `-use_go_run` option deprecated. Please replace `-use_go_run` with `-exec_mode=go_run` if you are using it. `-use_go_run` option will may be removed in the future version.